### PR TITLE
concurrency adjustment should not happen when mean is 0

### DIFF
--- a/balter/src/sampler.rs
+++ b/balter/src/sampler.rs
@@ -126,9 +126,9 @@ where
             .push((self.sampler.concurrency(), stats.mean));
 
         let tps_per_task = stats.mean / self.sampler.concurrency() as f64;
-        let new_concurrency = (self.sampler.tps_limit().get() as f64 / tps_per_task).ceil();
-        //Make sure not infinity in case of division by zero (when mean is 0)
-        if new_concurrency.is_finite() {
+        if tps_per_task != 0.0 {
+            //Make sure not infinity in case of division by zero (when mean is 0)
+            let new_concurrency = (self.sampler.tps_limit().get() as f64 / tps_per_task).ceil();
             let new_concurrency = (new_concurrency as usize).max(self.sampler.concurrency()).max(1);
             self.sampler.set_concurrency(new_concurrency);
         }

--- a/balter/src/sampler.rs
+++ b/balter/src/sampler.rs
@@ -126,11 +126,12 @@ where
             .push((self.sampler.concurrency(), stats.mean));
 
         let tps_per_task = stats.mean / self.sampler.concurrency() as f64;
-        let new_concurrency =
-            (self.sampler.tps_limit().get() as f64 / tps_per_task).ceil() as usize;
-        let new_concurrency = new_concurrency.max(self.sampler.concurrency()).max(1);
-
-        self.sampler.set_concurrency(new_concurrency);
+        let new_concurrency = (self.sampler.tps_limit().get() as f64 / tps_per_task).ceil();
+        //Make sure not infinity in case of division by zero (when mean is 0)
+        if new_concurrency.is_finite() {
+            let new_concurrency = (new_concurrency as usize).max(self.sampler.concurrency()).max(1);
+            self.sampler.set_concurrency(new_concurrency);
+        }
     }
 }
 


### PR DESCRIPTION
Handles division by zero in adjust_concurrency function

I'm not sure how to handle it though so I just removed adjustment